### PR TITLE
Update book/forms.rst

### DIFF
--- a/book/forms.rst
+++ b/book/forms.rst
@@ -847,11 +847,11 @@ de construction du formulaire « task » :
     namespace Acme\TaskBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
-    use Symfony\Component\Form\FormBuilder;
+    use Symfony\Component\Form\FormBuilderInterface;
 
     class TaskType extends AbstractType
     {
-        public function buildForm(FormBuilder $builder, array $options)
+        public function buildForm(FormBuilderInterface $builder, array $options)
         {
             $builder->add('task');
             $builder->add('dueDate', null, array('widget' => 'single_text'));


### PR DESCRIPTION
Salut, je découvre Symfony et j'ai trouvé une petite erreur dans la version FR du book.
L'erreur concerne la version 2.1 et les formulaires, on est supposés utiliser Symfony\Component\Form\FormBuilderInterface au lieu de Symfony\Component\Form\FormBuilder.

Link : http://symfony.com/fr/doc/master/book/forms.html#creer-des-classes-de-formulaire
