### PR TITLE
Change faux-ami with a more suitable translation

### DIFF
--- a/book/from_flat_php_to_symfony2.rst
+++ b/book/from_flat_php_to_symfony2.rst
@@ -75,7 +75,7 @@ impossible à maintenir. Il y a plusieurs problèmes qui doivent être résolus:
 .. note::
     Un autre problème non mentionné ici est le fait que la base de données est 
     liée à MySQL. Même si le sujet n'est pas couvert ici, Symfony intègre `Doctrine`_,
-    une librairie dédiée à l'abstraction des base de données 
+    une bibliothèque dédiée à l'abstraction des base de données
     et au mapping objet-relationnel.
     
 Retroussons-nous les manches et résolvons ces problèmes ainsi que d'autres.
@@ -372,7 +372,7 @@ fonction de l'URI demandée:
     <?php
     // index.php
 
-    // charge et initialise les librairies globales
+    // charge et initialise les bibliothèques globales
     require_once 'model.php';
     require_once 'controllers.php';
 
@@ -405,7 +405,7 @@ sont maintenant des fonctions PHP et ont été placés dans le fichier ``control
     }
 
 En tant que contrôleur frontal, ``index.php`` assume un nouveau rôle, celui
-d'inclure les librairies principales et de router l'application pour que l'un des
+d'inclure les bibliothèques principales et de router l'application pour que l'un des
 deux contrôleurs (les fonctions ``list_action()`` et ``show_action()``) soit appelé.
 En réalité, le contrôleur frontal commence à ressembler et à agir comme le mécanisme
 de Symfony2 qui prend en charge et achemine les requêtes.

--- a/book/installation.rst
+++ b/book/installation.rst
@@ -24,7 +24,7 @@ Télécharger une Distribution Symfony2
     lisez les documentations suivantes : `Apache`_ | `Nginx`_ .
 
 Les « distributions » Symfony2 sont des applications entièrement fonctionnelles
-qui incluent les librairies du coeur de Symfony2, une sélection de bundles utiles,
+qui incluent les bibliothèques du coeur de Symfony2, une sélection de bundles utiles,
 une arborescence pratique et une configuration par défaut. Quand vous téléchargez
 une distribution Symfony2, vous téléchargez un squelette d'application qui peut
 être immédiatement utilisé pour commencer à développer votre application.
@@ -188,7 +188,7 @@ Symfony elle-même - dans le répertoire ``vendor/``.
 Configuration et installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Maintenant, toutes les librairies tierces nécessaires sont dans le répertoire
+Maintenant, toutes les bibliothèques tierces nécessaires sont dans le répertoire
 ``vendor/``. Vous avez également une application par défaut installée dans le
 répertoire ``app/`` et un exemple de code dans le répertoire ``src/``.
 
@@ -315,7 +315,7 @@ cela se fait en créant le fichier ``.gitignore`` et en y ajoutant la ligne suiv
 Maintenant, le répertoire vendor ne sera pas commité sur votre système de gestion
 de code. C'est plutôt bien (en fait c'est génial !) car lorsque quelqu'un clone ou
 récupère le projet, il lui suffit de lancer la commande ``php bin/vendors install``
-pour récupérer toutes les librairies nécessaires.
+pour récupérer toutes les bibliothèques nécessaires.
 
 .. _`activer le support ACL`: https://help.ubuntu.com/community/FilePermissionsACLs
 .. _`http://symfony.com/download`: http://symfony.com/download

--- a/book/page_creation.rst
+++ b/book/page_creation.rst
@@ -443,7 +443,7 @@ a par défaut la même structure de répertoires basique et recommandée :
 
 * ``src/``: Tout le code PHP du projet est stocké ici;
 
-* ``vendor/``: Par convention, toutes les librairies tierces (additionnelles) sont placées ici;
+* ``vendor/``: Par convention, toutes les bibliothèques tierces (additionnelles) sont placées ici;
 
 * ``web/``: Le répertoire racine web qui contient tous les fichiers publiquement accessibles;
 
@@ -528,7 +528,7 @@ Nous en apprendrons plus sur ces répertoires dans de prochains chapitres.
 
     Lorsque Symfony se charge, un fichier spécial - ``app/autoload.php`` - est
     inclus. Ce fichier s'occupe de configurer l'autoloader qui chargera automatiquement
-    tous vos fichiers depuis le répertoire ``src/`` et toutes les librairies tierces
+    tous vos fichiers depuis le répertoire ``src/`` et toutes les bibliothèques tierces
     depuis le repertoire ``vendor/``.
 
     Grace à l'autoloader, vous n'avez jamais à vous soucier d'utiliser les instructions
@@ -549,7 +549,7 @@ Nous en apprendrons plus sur ces répertoires dans de prochains chapitres.
             src/Acme/HelloBundle/Controller/HelloController.php
 
     Typiquement, le seul moment où vous devrez vous soucier du fichier ``app/autoload.php``	
-    est quand vous inclurez des librairies tierces dans le repertoire ``vendor/``.
+    est quand vous inclurez des bibliothèques tierces dans le repertoire ``vendor/``.
     Pour plus d'informations sur le chargement automatique, voir 
     :doc: `Comment charger automatiquement des classes</components/class_loader>`.
 
@@ -1007,8 +1007,8 @@ en tête :
 
 * chaque projet contient juste quelques répertoires principaux : ``web/`` (ressources
   web et contrôleurs frontaux), ``app/`` (configuration), ``src/`` (vos bundles),
-  et ``vendor/`` (librairies tierces) (il y a aussi un répertoire ``bin/`` qui est utilisé
-  pour la mise à jour des librairies vendors);
+  et ``vendor/`` (bibliothèques tierces) (il y a aussi un répertoire ``bin/`` qui est utilisé
+  pour la mise à jour des bibliothèques vendors);
 
 * chaque fonctionnalité de Symfony2 (incluant le noyau du framework) est organisée
   dans un *bundle*, qui est un ensemble structuré de fichiers pour cette fonctionnalité;

--- a/book/performance.rst
+++ b/book/performance.rst
@@ -113,13 +113,13 @@ Veuillez noter qu'il y a deux inconvénients à utiliser un fichier d'amorçage 
 
 * le fichier nécessite d'être régénéré à chaque fois que les fichiers sources 
   originaux changent (à savoir quand vous mettez à jour le code source de Symfony2
-  ou une librairie tierce),
+  ou une bibliothèque tierce),
 
 * lors du débogage, vous devrez placer des points d'arrêt (breakpoints) dans ce fichier
   d'amorçage.
 
 Si vous utilisez l'édition Symfony2 standard, les fichiers d'amorçage sont automatiquement
-regénérés après avoir mis à jour les librairies tierces (« vendors »)
+regénérés après avoir mis à jour les bibliothèques tierces (« vendors »)
 grâce à la commande ``php bin/vendors install``.
 
 Fichiers d'amorçage et caches de byte code

--- a/book/security.rst
+++ b/book/security.rst
@@ -22,7 +22,7 @@ Comme la meilleure façon d'apprendre est par l'exemple, alors plongeons dans le
 
 .. note::
 
-    Le `composant de sécurité` de Symfony est disponible en tant que librairie indépendante, 
+    Le `composant de sécurité` de Symfony est disponible en tant que bibliothèque indépendante,
     et peut être utilisé pour tout projet PHP.
 
 Exemple simple: l'authentification HTTP 

--- a/book/templating.rst
+++ b/book/templating.rst
@@ -665,7 +665,7 @@ Contenu asynchrone avec hinclude.js
 .. versionadded:: 2.1 
     hinclude.js support was added in Symfony 2.1
 
-Les contrôleurs peuvent être imbriqués de façon asynchrone avec la librairie
+Les contrôleurs peuvent être imbriqués de façon asynchrone avec la bibliothèque
 javascript hinclude.js_.
 Comme le contenu imbriqué vient d'une autre page (un d'un autre contrôleur),
 Symfony2 utiliser le helper standard ``render`` pour configurer les tags ``hinclude``:

--- a/bundles/DoctrineMigrationsBundle/index.rst
+++ b/bundles/DoctrineMigrationsBundle/index.rst
@@ -14,9 +14,9 @@ Installation
 ------------
 
 Les migrations Doctrine pour Symfony sont maintenues dans le `DoctrineMigrationsBundle`_.
-Le bundle utilise la librairie externe `Doctrine Database Migrations`_.
+Le bundle utilise la bibliothèque externe `Doctrine Database Migrations`_.
 
-Suivez ces étapes pour installer le bundle et la librairie dans l'Edition
+Suivez ces étapes pour installer le bundle et la bibliothèque dans l'Edition
 Standard de Symfony. Ajoutez le code suivant à votre fichier ``composer.json`` :
 
 .. code-block:: json
@@ -27,7 +27,7 @@ Standard de Symfony. Ajoutez le code suivant à votre fichier ``composer.json`` 
         }
     }
 
-Mettez à jour vos librairies « vendor » :
+Mettez à jour vos bibliothèques « vendor » :
 
 .. code-block:: bash
 
@@ -38,8 +38,8 @@ Si tout s'est bien passé, le ``DoctrineMigrationsBundle`` peut maintenant
 
 .. note::
 
-    ``DoctrineMigrationsBundle`` installe la librairie `Doctrine Database Migrations`_.
-    La librairie peut être trouvée dans le répertoire ``vendor/doctrine/migrations``.
+    ``DoctrineMigrationsBundle`` installe la bibliothèque `Doctrine Database Migrations`_.
+    La bibliothèque peut être trouvée dans le répertoire ``vendor/doctrine/migrations``.
 
 Enfin, assurez-vous d'avoir activé le bundle dans le fichier ``AppKernel.php`` en
 ajoutant le code suivant :
@@ -181,7 +181,7 @@ Générer les migrations automatiquement
 --------------------------------------
 
 En réalité, vous devrez rarement avoir besoin d'écrire les migrations manuellement,
-puisque la librairie peut générer les classes de migration automatiquement en
+puisque la bibliothèque peut générer les classes de migration automatiquement en
 comparant vos informations de « mapping » Doctrine (c'est-à-dire ce à quoi votre
 base de données *devrait* ressembler) avec la structure de votre base de données
 actuelle.

--- a/cookbook/assetic/asset_management.rst
+++ b/cookbook/assetic/asset_management.rst
@@ -176,9 +176,9 @@ CoffeeScript en JavaScript ou convertir vos fichiers SASS en CSS.
 En fait, Assetic possède une longue liste de filtres.
 
 Plusieurs de ces filtres ne font pas le travail directement, mais utilisent
-des librairies tierces pour faire le gros du travail. Cela signifie que vous
-devrez souvent installer une librairie tierce pour utiliser un filtre. Le grand
-avantage d'utiliser Assetic pour faire appel à ces librairies (plutôt que de les
+des bibliothèques tierces pour faire le gros du travail. Cela signifie que vous
+devrez souvent installer une bibliothèque tierce pour utiliser un filtre. Le grand
+avantage d'utiliser Assetic pour faire appel à ces bibliothèques (plutôt que de les
 utiliser directement) est qu'au lieu de les exécuter à la main après avoir modifié
 les fichiers, Assetic prendra tout en charge pour vous, et supprimera définitivement
 cette étape du processus de développement et de déploiement.

--- a/cookbook/doctrine/common_extensions.rst
+++ b/cookbook/doctrine/common_extensions.rst
@@ -8,7 +8,7 @@ Doctrine2 est très flexible, et la communauté a déjà créé une série d'ext
 Doctrine très pratiques afin de vous aider avec les tâches usuelles liées aux
 entités.
 
-Une librairie en particulier - la librairie `DoctrineExtensions`_ - fournit
+Une bibliothèque en particulier - la bibliothèque `DoctrineExtensions`_ - fournit
 l'intégration de fonctionnalités pour les comportements (Behaviors) `Sluggable`_,
 `Translatable`_, `Timestampable`_, `Loggable`_, `Tree`_ et `Sortable`_
 
@@ -18,7 +18,7 @@ Toutefois, pour installer/activer chaque extension, vous devez enregistrer
 et activer un :doc:`Ecouteur d'évènement (Event Listener)</cookbook/doctrine/event_listeners_subscribers>`.
 Pour faire cela, vous avez deux possibilités :
 
-#. Utiliser le bundle `StofDoctrineExtensionsBundle`_, qui intègre la librairie ci-dessus.
+#. Utiliser le bundle `StofDoctrineExtensionsBundle`_, qui intègre la bibliothèque ci-dessus.
 
 #. Implémenter ces services directement en suivant la documentation pour l'intégration dans
    Symfony2 : `Installer les extensions Gedmo Doctrine2 dans Symfony2`_

--- a/cookbook/web_services/php_soap_extension.rst
+++ b/cookbook/web_services/php_soap_extension.rst
@@ -7,7 +7,7 @@ Comment créer des web services SOAP à l'intérieur d'un contrôleur Symfony2
 Configurer un contrôleur afin qu'il agisse comme un serveur est réalisé simplement
 avec quelques outils. Vous devez, bien sûr, avoir installé l'extension `PHP SOAP`_.
 Comme l'extension PHP SOAP ne peut actuellement pas générer un WSDL, vous devez soit
-en créer un, soit utiliser un générateur provenant d'une librairie tierce.
+en créer un, soit utiliser un générateur provenant d'une bibliothèque tierce.
 
 .. note::
 

--- a/glossary.rst
+++ b/glossary.rst
@@ -13,7 +13,7 @@ Glossaire
 
    Projet
         Un *Projet* est un répertoire composé d'une Application, un ensemble de
-        bundles, des librairies tierces, un chargeur automatique (autoloader), et
+        bundles, des bibliothèques tierces, un chargeur automatique (autoloader), et
         des contrôleurs frontaux.
 
    Application
@@ -73,12 +73,12 @@ Glossaire
         un environnement de ``prod`` qui est optimisé pour de meilleures performances.
 
    Vendor
-        Un *vendor* est un fournisseur de librairies PHP et de bundles, incluant
+        Un *vendor* est un fournisseur de bibliothèques PHP et de bundles, incluant
         Symfony2 lui-même. Malgré la connotation commercial du terme, les vendors
         de Symfony sont souvent (et même très souvent) des logiciels libres. Toute
-        librairie que vous ajoutez dans votre projet Symfony2 devrait se trouver
+        bibliothèque que vous ajoutez dans votre projet Symfony2 devrait se trouver
         dans le répertoire ``vendor``. Lisez
-        :ref:`L'Architecture: Utilisation de librairies externes <using-vendors>`.
+        :ref:`L'Architecture: Utilisation de bibliothèques externes <using-vendors>`.
 
    Acme
         *Acme* est un exemple d'entreprise utilisé dans Symofny pour les exemples et
@@ -99,7 +99,7 @@ Glossaire
 
    Kernel
         Le *Kernel* (noyau) est le coeur de Symfony2. L'objet Kernel prend en charge
-        les requêtes HTTP en utilisant tous les bundles et librairies qui sont enregistrés.
+        les requêtes HTTP en utilisant tous les bundles et bibliothèques qui sont enregistrés.
         Lisez :ref:`L'Architecture : Le répertoire Application<the-app-dir>` et le chapitre
         :doc:`/book/internals`.
 

--- a/quick_tour/the_architecture.rst
+++ b/quick_tour/the_architecture.rst
@@ -17,7 +17,7 @@ recommandée d'une application Symfony2 :
 
 * ``app/``:    La configuration de l'application,
 * ``src/``:    Le code PHP du projet,
-* ``vendor/``: Les librairies tierces,
+* ``vendor/``: Les bibliothèques tierces,
 * ``web/``:    Le répertoire Web racine.
 
 Le répertoire ``web/``
@@ -323,13 +323,13 @@ qui décidez.
 
 .. _using-vendors:
 
-Utilisation de librairies externes (Vendors)
+Utilisation de bibliothèques externes (Vendors)
 --------------------------------------------
 
-Il y a de fortes probabilités que votre application dépende de librairies tierces.
+Il y a de fortes probabilités que votre application dépende de bibliothèques tierces.
 Celles-ci doivent être stockées dans le répertoire ``vendor/``. Ce
-répertoire contient déjà les librairies de Symfony2, la librairie SwiftMailer,
-l'ORM Doctrine, le système de template Twig et d'autres librairies et bundles.
+répertoire contient déjà les bibliothèques de Symfony2, la bibliothèque SwiftMailer,
+l'ORM Doctrine, le système de template Twig et d'autres bibliothèques et bundles.
 
 Comprendre le Cache et les Logs
 -------------------------------


### PR DESCRIPTION
Search "librairie" and replace it with "bibliothèque".
library is a false cognate, even when speaking computer science:
From http://fr.wikipedia.org/wiki/Biblioth%C3%A8que_logicielle:

> On retrouve parfois le terme librairie issu du faux ami anglais library. Librairie se traduisant bookshop en anglais c'est donc un abus de langage et une erreur.
