### PR TITLE
Update cookbook/form/dynamic_form_generation.rst

### DIFF
--- a/cookbook/form/dynamic_form_generation.rst
+++ b/cookbook/form/dynamic_form_generation.rst
@@ -96,10 +96,10 @@ cela, le souscripteur pourrait ressembler à quelque chose comme ça::
     // src/Acme/DemoBundle/Form/EventListener/AddNameFieldSubscriber.php
     namespace Acme\DemoBundle\Form\EventListener;
 
-    use Symfony\Component\Form\Event\DataEvent;
     use Symfony\Component\Form\FormFactoryInterface;
     use Symfony\Component\EventDispatcher\EventSubscriberInterface;
     use Symfony\Component\Form\FormEvents;
+    use Symfony\Component\Form\FormEvent;
 
     class AddNameFieldSubscriber implements EventSubscriberInterface
     {


### PR DESCRIPTION
in the class AddNameFieldSubscriber :

not used  "use Symfony\Component\Form\Event\DataEvent;"

missing "use Symfony\Component\Form\FormEvent;"
for "public function preSetData(FormEvent $event)"
