### PR TITLE
Fix autoload.php link (2.1) for book/performance

### DIFF
--- a/book/performance.rst
+++ b/book/performance.rst
@@ -133,5 +133,5 @@ d'amorçage.
 
 .. _`caches de byte code`: http://en.wikipedia.org/wiki/List_of_PHP_accelerators
 .. _`APC`: http://php.net/manual/en/book.apc.php
-.. _`autoloader.php`: https://github.com/symfony/symfony-standard/blob/2.0/app/autoload.php
+.. _`autoloader.php`: https://github.com/symfony/symfony-standard/blob/2.1/app/autoload.php
 .. _`fichier d'amorçage`: https://github.com/sensio/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php


### PR DESCRIPTION
Link was pointed on 2.0 branch of symfony/symfony-standard, changed for 2.1.
