### PR TITLE
Fixed broken link in routing.rst

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -1059,7 +1059,7 @@ de chaque route chargée depuis la nouvelle ressource de routage.
 .. tip::
 
     Vous pouvez également définir les routes en utilisant les annotations.
-    Lisez la:doc:`documentation du FrameworkExtraBundle</bundles/SensioFrameworkExtraBundle/annotations/routing>`
+    Lisez la :doc:`documentation du FrameworkExtraBundle</bundles/SensioFrameworkExtraBundle/annotations/routing>`
     pour savoir comment faire.
 
 .. index::


### PR DESCRIPTION
Fixed broken link to FrameworkExtraBundle documentation in routing.rst due to a missing space.
