### PR TITLE
correction

### DIFF
--- a/cookbook/controller/service.rst
+++ b/cookbook/controller/service.rst
@@ -52,7 +52,7 @@ Utiliser les annotations de routage
 -----------------------------------
 
 Lorsque vous utilisez les annotations pour définir le routage dans un contrôleur
-défini comme service, vous devrez votre service comme suit::
+défini comme service, vous devrez spécifier votre service comme suit::
 
     /**
      * @Route("/blog", service="my_bundle.annot_controller")


### PR DESCRIPTION
ajout du mot "spécifier" dans 
Lorsque vous utilisez les annotations pour définir le routage dans un contrôleur
défini comme service, vous devrez spécifier votre service comme suit::
