### PR TITLE
Update security.rst

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -1598,7 +1598,7 @@ la fonction helper intégrée :
 
     Si vous utilisez cette fonction et que vous ne vous trouvez pas à une URL pour laquelle
     un pare-feu est actif, une exception sera lancée. Encore une fois, c'est toujours une
-    bonne idée d'avoir un pare-feu qui couvre toutes les URLs (comme c'e'st montré dans ce chapitre).
+    bonne idée d'avoir un pare-feu qui couvre toutes les URLs (comme c'est montré dans ce chapitre).
 
 Contrôle d'accès dans les Contrôleurs
 -------------------------------------


### PR DESCRIPTION
typo on line 1601 : "c'e'st" should be "c'est"
on book 2.2 and 2.3
