### PR TITLE
Fixed link to session doc

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -381,7 +381,6 @@ Afin de rediriger le client vers une autre URL, vous pouvez utilisez la classe
 Session
 -------
 
-TBD -- Cette partie n'est actuellement pas écrite et sera certainement retravaillée
-dans Symfony en version 2.1.
+Les informations concernant la session se trouvent dans leur propre document : :doc:`/components/http_foundation/sessions`.
 
 .. _Packagist: https://packagist.org/packages/symfony/http-foundation


### PR DESCRIPTION
The Session section was referring to a re-documentation to be done with Symfony version 2.1 (!). I just fixed it by providing the link to the actual session documentation, doing the exact same thing as the english doc.
