### PR TITLE
Négation incomplète + conjugaison

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -382,7 +382,7 @@ Contexte du Firewall
 
 La plupart des applications n'ont besoin que d'un seul :ref:`firewall<book-security-firewalls>`.
 Mais si votre application *doit* utiliser plusieurs firewalls, vous devez
-prendre en compte que si vous êtes authentifier dans un firewall, vous n'
+prendre en compte que si vous êtes authentifié dans un firewall, vous n'
 êtes pas automatiquement authentifié dans un autre. En d'autre termes, les
 systèmes ne se partagent pas un contexte commun: chaque firewall agit comme
 un système de sécurité distinct.


### PR DESCRIPTION
Bizarrement cette erreur apparaît dans la [documentation](http://symfony.com/fr/doc/2.2/reference/configuration/security.html#contexte-du-firewall) de la version 2.2 mais n'est pas dans le code du [fichier](https://github.com/symfony-fr/symfony-docs-fr/blob/2.2/reference/configuration/security.rst)
