### PR TITLE
Fix method "getTotalTime" to "getDuration".

### DIFF
--- a/cookbook/testing/profiling.rst
+++ b/cookbook/testing/profiling.rst
@@ -37,7 +37,7 @@ qu'il est disponible (il est activé par défaut dans l'environnement de ``test`
                 $this->assertLessThan(10, $profile->getCollector('db')->getQueryCount());
 
                 // Vérifier le temps utilisé par le framework
-                $this->assertLessThan((500, $profile->getCollector('time')->getTotalTime());
+                $this->assertLessThan((500, $profile->getCollector('time')->getDuration());
             }
         }
     }


### PR DESCRIPTION
See http://symfony.com/doc/current/cookbook/testing/profiling.html and http://api.symfony.com/2.3/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.html#method_getDuration
