### PR TITLE
Deprecated method used

### DIFF
--- a/bundles/DoctrineMongoDBBundle/form.rst
+++ b/bundles/DoctrineMongoDBBundle/form.rst
@@ -105,10 +105,16 @@ Ensuite, créez le formulaire pour le modèle ``User``::
                'type' => 'password'
             ));
         }
-
-        public function getDefaultOptions(array $options)
+        
+        /**
+         * Set default
+         * @param OptionsResolverInterface $resolver
+         */
+        public function setDefaultOptions(OptionsResolverInterface $resolver)
         {
-            return array('data_class' => 'Acme\AccountBundle\Document\User');
+            $resolver->setDefaults(array(
+                'data_class' => 'Acme\AccountBundle\Document\User',
+            ));
         }
 
         public function getName()


### PR DESCRIPTION
This method "getDefaultOptions" is deprecated on Symfony 2.3. And the new one "setDefaultOptions" need to be used with "setDefaults" Method from the resolver parameter.
