### PR TITLE
Update checkbox.rst // no checked option

### DIFF
--- a/reference/forms/types/checkbox.rst
+++ b/reference/forms/types/checkbox.rst
@@ -12,7 +12,6 @@ défini à true. Si la case n'est pas cochée, le champ sera défini à false.
 | Rendu comme | Champ ``input`` ``checkbox``                                           |
 +-------------+------------------------------------------------------------------------+
 | Options     | - `value`_                                                             |
-|             | - `checked`_                                                           |
 +-------------+------------------------------------------------------------------------+
 | Options     | - `required`_                                                          |
 | héritées    | - `label`_                                                             |
@@ -48,10 +47,6 @@ value
 La valeur qui est effectivement utilisée comme valeur de la checkbox. Cela n'affecte
 pas la valeur qui est définie sur votre objet.
 
-checked
-~~~~~~~
-
-**type**: ``mixed`` **default**: ``1``
 
 Options héritées
 ----------------


### PR DESCRIPTION
Salut !

En comparant avec la version anglaise
http://symfony.com/doc/master/reference/forms/types/checkbox.html on remarque que l'option checked n'existe pas (plus?).

Je viens de tester le code suivant

``` php
$builder->add('remember_me', 'checkbox',
            array(
                'checked' => true,
                )
            )
```

Et effectivement, Symfony me renvoie une erreur:

```
The option "checked" does not exist. Known options are: "action", "attr", "auto_initialize", "block_name", "by_reference", "cascade_validation", "compound", "constraints", "csrf_field_name", "csrf_message", "csrf_protection", "csrf_provider", "data", "data_class", "disabled", "empty_data", "error_bubbling", "error_mapping", "extra_fields_message", "inherit_data", "intention", "invalid_message", "invalid_message_parameters", "label", "label_attr", "mapped", "max_length", "method", "pattern", "post_max_size_message", "property_path", "read_only", "required", "translation_domain", "trim", "validation_groups", "value", "virtual"
```
