### PR TITLE
Erreur de conjugaison

### DIFF
--- a/book/templating.rst
+++ b/book/templating.rst
@@ -562,7 +562,7 @@ L'inclusion de ce template dans tout autre template est simple :
             <?php endforeach; ?>
         <?php $view['slots']->stop() ?>
 
-Le template est inclu via l'utilisation de la balise ``{% include %}``. 
+Le template est inclus via l'utilisation de la balise ``{% include %}``. 
 Remarquons que le nom du template suit la même convention habituelle. Le
 template ``articleDetails.html.twig`` utilise une variable ``article``. Elle est
 passée au template ``list.html.twig`` en utilisant la commande ``with``.


### PR DESCRIPTION
Il manquait le S à inclus. Les deux autres "est inclus" de la page sont écrit correctement.
