### PR TITLE
Update "Form type extension" cookbook for Symfony 2.2

### DIFF
--- a/cookbook/form/create_form_type_extension.rst
+++ b/cookbook/form/create_form_type_extension.rst
@@ -188,10 +188,9 @@ actuelle pour l'afficher dans la vue::
     namespace Acme\DemoBundle\Form\Extension;
 
     use Symfony\Component\Form\AbstractTypeExtension;
-    use Symfony\Component\Form\FormBuilder;
     use Symfony\Component\Form\FormView;
     use Symfony\Component\Form\FormInterface;
-    use Symfony\Component\Form\Util\PropertyPath;
+    use Symfony\Component\PropertyAccess\PropertyAccess;
     use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
     class ImageTypeExtension extends AbstractTypeExtension
@@ -228,10 +227,15 @@ actuelle pour l'afficher dans la vue::
             if (array_key_exists('image_path', $options)) {
                 $parentData = $form->getParent()->getData();
 
-                $propertyPath = new PropertyPath($options['image_path']);
-                $imageUrl = $propertyPath->getValue($parentData);
+                if (null !== $parentData) {
+                    $accessor = PropertyAccess::getPropertyAccessor();
+                    $imageUrl = $accessor->getValue($parentData, $options['image_path']);
+                } else {
+                     $imageUrl = null;
+                }
+                
                 // définit une variable "image_url" qui sera disponible à l'affichage du champ
-                $view->set('image_url', $imageUrl);
+                $view->vars['image_url'] = $imageUrl;
             }
         }
 


### PR DESCRIPTION
Some deprecated calls where made and have been replaced by their newer counterparts.
