### PR TITLE
[Config] Fix array node definition

### DIFF
--- a/components/config/definition.rst
+++ b/components/config/definition.rst
@@ -151,10 +151,12 @@ de noeuds variable::
 
     $rootNode
         ->arrayNode('connection')
-            ->scalarNode('driver')->end()
-            ->scalarNode('host')->end()
-            ->scalarNode('username')->end()
-            ->scalarNode('password')->end()
+            ->children()
+                ->scalarNode('driver')->end()
+                ->scalarNode('host')->end()
+                ->scalarNode('username')->end()
+                ->scalarNode('password')->end()
+            ->end()
         ->end()
     ;
 


### PR DESCRIPTION
There is a missing call to the `children()` method.

See code bellow or the english version https://github.com/symfony/symfony-docs/blob/master/components/config/definition.rst#array-nodes
