### PR TITLE
Fixed error for option read_only

### DIFF
--- a/reference/forms/types/options/read_only.rst.inc
+++ b/reference/forms/types/options/read_only.rst.inc
@@ -3,5 +3,5 @@ read_only
 
 **type**: ``Boolean`` **default**: ``false``
 
-Si cette option est à true, le champ sera affiché avec l'attribut ``disabled``,
-de telle sorte que le champ ne soit pas modiable.
+Si cette option est à true, le champ sera affiché avec l'attribut ``readonly``,
+de telle sorte que le champ ne soit pas modifiable.


### PR DESCRIPTION
The `read_only` option will render as an `readonly` HTML attribute and NOT by a `disabled` attribute.

Fixed a typo
