### PR TITLE
[Form] Fix typo in types options

### DIFF
--- a/reference/forms/types/options/label.rst.inc
+++ b/reference/forms/types/options/label.rst.inc
@@ -1,7 +1,7 @@
 label
 ~~~~~
 
-**type**: ``string`` **default**: Le libellé est à deviné à partir du nom du champ.
+**type**: ``string`` **default**: Le libellé est deviné à partir du nom du champ.
 
 Définit le libellé qui sera utilisé à l'affichage du champ. Le libellé peut aussi
 être directement défini dans le template :


### PR DESCRIPTION
I opened this PR against branch 2.3 as in official english doc, it's the lowest branch supported. Then I saw that in the readme of this repos, it's 2.1. Should I re-open this PR against it?
