### PR TITLE
Update use_virtuals_forms.rst

### DIFF
--- a/cookbook/form/use_virtuals_forms.rst
+++ b/cookbook/form/use_virtuals_forms.rst
@@ -101,11 +101,11 @@ français)::
                 ->add('country', 'text');
         }
 
-        public function getDefaultOptions(array $options)
+        public function setDefaultOptions(OptionsResolverInterface $resolver)
         {
-            return array(
+            $resolver->setDefaults(array(
                 'virtual' => true,
-            );
+            ));
         }
 
         public function getName()


### PR DESCRIPTION
getDefaultOptions() method has been removed from FormTypeInterface in 2.3 and should be replaced by setDefaultOptions(OptionsResolverInterface $resolver). (information given in UPGRADE-2.1.md)
