### PR TITLE
Update monolog.rst

### DIFF
--- a/cookbook/logging/monolog.rst
+++ b/cookbook/logging/monolog.rst
@@ -38,7 +38,7 @@ le conteneur dans un contrôleur::
 
     $logger = $this->get('logger');
     $logger->info('Nous avons récupéré le logger');
-    $logger->err('Une erreur est survenue');
+    $logger->error('Une erreur est survenue');
 
 .. tip::
 


### PR DESCRIPTION
Change method 'err' to 'error' in the example because the 'err' method is deprecated and to be removed. (As specified in this file : vendor/symfony/symfony/src/Symfony/Bridge/Monolog/Logger.php on line 42 : @deprecated since 2.2, to be removed in 3.0. Use error() which is PSR-3 compatible.)
