### PR TITLE
Fix parse error in php configuration for type constraints

### DIFF
--- a/reference/constraints/Type.rst
+++ b/reference/constraints/Type.rst
@@ -72,7 +72,7 @@ Utilisation de base
             {
                 $metadata->addPropertyConstraint('age', new Assert\Type(array(
                     'type'    => 'integer',
-                    'message' => 'La valeur {{ value }} n'est pas un type {{ type }} valide.',
+                    'message' => "La valeur {{ value }} n'est pas un type {{ type }} valide.",
                 )));
             }
         }


### PR DESCRIPTION
This error appears in 2.3.

Quotes error
