### PR TITLE
Removed wrong reference to cookbook

### DIFF
--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -490,9 +490,6 @@ différents points.
 Pour un exemple complet de cet écouteur (« listener » en anglais), lisez l'article
 du cookbook :doc:`/cookbook/service_container/event_listener`.
 
-Pour un autre exemple pratique d'un écouteur du « kernel » (« noyau » en français),
-référez-vous à l'article du cookbook suivant : :doc:`/cookbook/request/mime_type`.
-
 Écouteurs d'évènements du noyau de référence
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 2.5 |
| Fixed tickets |  |

The /cookbook/request/mime_type article does not contain an example to register a kernel listener since 2.5
