### PR TITLE
Synchro avec la doc anglaise

### DIFF
--- a/bundles/DoctrineMigrationsBundle/index.rst
+++ b/bundles/DoctrineMigrationsBundle/index.rst
@@ -23,6 +23,7 @@ Standard de Symfony. Ajoutez le code suivant à votre fichier ``composer.json`` 
 
     {
         "require": {
+            "doctrine/migrations": "dev-master",
             "doctrine/doctrine-migrations-bundle": "dev-master"
         }
     }


### PR DESCRIPTION
Ajout de la dépendance "doctrine/migrations": "dev-master" requise par le bundle "doctrine/doctrine-migrations-bundle"
