### PR TITLE
Update doctrine.rst

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -716,7 +716,7 @@ Imaginons que vous souhaitez récupérer tous les produits dont le prix est sup�
 
 .. code-block:: php
 
-    $em = $this->getDoctrine()->getEntityManager();
+    $em = $this->getDoctrine()->getManager();
     $query = $em->createQuery(
         'SELECT p
         FROM AcmeStoreBundle:Product p


### PR DESCRIPTION
Dans la section "Requêter des objets avec DQL"
Deprecated: getEntityManager is deprecated since Symfony 2.1. Use getManager instead
