### PR TITLE
Add a return value in an example

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -152,6 +152,7 @@ Vous pouvez poser une question et valider une réponse cachée::
         if (trim($value) == '') {
             throw new \Exception('Le mot de passe ne peut pas être vide');
         }
+        return $value;
     };
 
     $password = $dialog->askHiddenResponseAndValidate(


### PR DESCRIPTION
Without the return value, this helper doesn't return the value enter by the user
