### PR TITLE
Change phpunit install from pear to composer

### DIFF
--- a/contributing/code/tests.rst
+++ b/contributing/code/tests.rst
@@ -13,8 +13,7 @@ récent :
 
 .. code-block:: bash
     
-    $ pear config-set auto_discover 1
-    $ pear install pear.phpunit.de/PHPUnit
+    $ composer global require "phpunit/phpunit=4.2.*"
 
 Dépendances (facultatif)
 ------------------------


### PR DESCRIPTION
Accordind to phpunit.de :
pear.phpunit.de will be shut down no later than December, 31 2014. Using the PEAR Installer to install PHPUnit is no longer supported.
