### PR TITLE
Dialoghelper missing translation double quote typo

### DIFF
--- a/components/console/helpers/dialoghelper.rst
+++ b/components/console/helpers/dialoghelper.rst
@@ -60,7 +60,7 @@ Autocompletion
     L'autocomplétion pour les questions a été ajoutée dans Symfony 2.2.
 
 Vous pouvez aussi spécifier un tableau de réponses possibles pour une question
-donnée. La réponse de l'utiliateur sera auto-complétée à mesure qu'il tape::
+donnée. La réponse de l'utilisateur sera auto-complétée à mesure qu'il tape::
 
     $dialog = $this->getHelperSet()->get('dialog');
     $bundleNames = array('AcmeDemoBundle', 'AcmeBlogBundle', 'AcmeStoreBundle');


### PR DESCRIPTION
Hello, 

there was still a message in english and a problem with simple quote/double quote in the functional test.

In the process I've fixed some typo.

Hope this helps :beers: 

Symfony FTW !
