### PR TITLE
Fix typo in use statement

### DIFF
--- a/components/http_foundation/session_configuration.rst
+++ b/components/http_foundation/session_configuration.rst
@@ -85,7 +85,7 @@ peuvent vous servir d'exemples si vous souhaitez écrire le(s) vôtre(s).
 Exemple d'utilisation::
 
     use Symfony\Component\HttpFoundation\Session\Session;
-    use Symfony\Component\HttpFoundation\Session\Storage\SessionStorage;
+    use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
     use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
     $storage = new NativeSessionStorage(array(), new PdoSessionHandler());


### PR DESCRIPTION
Fix use statement for a non existent class.
This is already fixed in english version.
