### PR TITLE
Fixed 2 typos in testing Doctrine and development pages

### DIFF
--- a/contributing/community/releases.rst
+++ b/contributing/community/releases.rst
@@ -24,7 +24,7 @@ La période de six mois est divisées en deux phases :
 
 * *Stabilisation*: *Deux mois* pour corriger les bugs, préparer la version et
   attendre que tout l'écosystème Symfony (bibliothèques tierces, bundles et
-  projets qui utilisent Symfony) se mettent à jour.
+  projets qui utilisent Symfony) se mette à jour.
 
 Durant la phase de développement, toute nouvelle fonctionnalité peut être mise
 de côté si elle n'est pas finalisée à temps, ou si elle n'est pas suffisamment

--- a/cookbook/testing/doctrine.rst
+++ b/cookbook/testing/doctrine.rst
@@ -10,7 +10,7 @@ travaillez avec quelque chose qui est réellement sensé être testé avec une
 véritable connexion à une base de données.
 
 Heureusement, vous pouvez facilement tester vos requêtes avec une vraie
-base de données, comme décrit ci-dessous
+base de données, comme décrit ci-dessous.
 
 .. _cookbook-doctrine-repo-functional-test:
 


### PR DESCRIPTION
See https://github.com/symfony-fr/symfony-docs-fr/issues/604

cookbook/testing/doctrine.html : added missing dot

contributing/community/releases.html : verb agreement