### PR TITLE
Update introduction.rst

### DIFF
--- a/components/http_foundation/introduction.rst
+++ b/components/http_foundation/introduction.rst
@@ -399,7 +399,7 @@ représenter par une fonction PHP au lieu d'une chaine de caractères::
 
 .. note::
 
-    La fonction ``flush()`` ne vide par le tampon. Si ``ob_start()`` a
+    La fonction ``flush()`` ne vide pas le tampon. Si ``ob_start()`` a
     été appelé avant ou si l'option ``output_buffering`` du ``php.ini``
     est activée, vous devrez appeler ``ob_flush()`` avant ``flush()``.
 


### PR DESCRIPTION
#632 fix word "par" mistaken for "pas" in components/http_foundation/introduction.rst, #creer-un-flux-de-reponse section