### PR TITLE
Update security.rst

### DIFF
--- a/book/security.rst
+++ b/book/security.rst
@@ -820,7 +820,7 @@ l'autorisation dans un contrôleur::
     // ...
     public function helloAction($name)
     {
-        if (false === $this->get('security.context')->isGranted('ROLE_ADMIN')) {
+        if (false === $this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
             throw new AccessDeniedException();
         }
         // ...


### PR DESCRIPTION
"security.context" is deprecated in 2.6, use "security.authorization_checker" instead see http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements