### PR TITLE
Wrong digest generation

### DIFF
--- a/cookbook/security/custom_authentication_provider.rst
+++ b/cookbook/security/custom_authentication_provider.rst
@@ -236,7 +236,7 @@ l'en-tête ``PasswordDigest`` correspond au mot de passe de l'utilisateur.
             file_put_contents($this->cacheDir.'/'.$nonce, time());
 
             // Valide le Secret
-            $expected = base64_encode(sha1(base64_decode($nonce).$created.$secret, true));
+            $expected = base64_encode(sha1($nonce.$created.$secret, true));
 
             return $digest === $expected;
         }


### PR DESCRIPTION
I was reading docs about WSSE
 * http://www.xml.com/pub/a/2003/12/17/dive.html
 * http://www.teria.com/~koseki/tools/wssegen/

The digest generated by the WsseProvider doesn't match those generated by online generator. I think it is a typo, by removing base64_decode the digest is correct.