### PR TITLE
The option "label_attr" does not exist anymore

### DIFF
--- a/reference/forms/types/button.rst
+++ b/reference/forms/types/button.rst
@@ -15,7 +15,6 @@ Un simple bouton non responsive.
 | Options              | - `attr`_                                                            |
 |                      | - `disabled`_                                                        |
 |                      | - `label`_                                                           |
-|                      | - `label_attr`_                                                      |
 |                      | - `translation_domain`_                                              |
 +----------------------+----------------------------------------------------------------------+
 | Type parent          | aucun                                                                |
@@ -31,8 +30,6 @@ Options
 .. include:: /reference/forms/types/options/button_disabled.rst.inc
 
 .. include:: /reference/forms/types/options/button_label.rst.inc
-
-.. include:: /reference/forms/types/options/label_attr.rst.inc
 
 .. include:: /reference/forms/types/options/button_translation_domain.rst.inc
 


### PR DESCRIPTION
The option "label_attr" does not exist. Known options are: "attr", "auto_initialize", "block_name", "disabled", "icon", "icon_color", "label", "label_format", "translation_domain".

My Symfony version : 2.6.7