### PR TITLE
Update best_practices.rst

### DIFF
--- a/cookbook/bundles/best_practices.rst
+++ b/cookbook/bundles/best_practices.rst
@@ -302,4 +302,4 @@ En savoir plus grâce au Cookbook
 
 * :doc:`/cookbook/bundles/extension`
 
-.. _standards: http://symfony.com/PSR0
+.. _standards: http://www.php-fig.org/psr/psr-4/


### PR DESCRIPTION
http://symfony.com/PSR0 return 404.
As of 2014-10-21 PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative.