### PR TITLE
EventDispatcher use Mediator pattern and not Observer's

### DIFF
--- a/components/event_dispatcher/introduction.rst
+++ b/components/event_dispatcher/introduction.rst
@@ -23,7 +23,7 @@ résoudre avec de l'héritage simple, et l'héritage multiple (s'il était
 possible avec PHP) possède ses propres inconvénients.
 
 Le composant Répartiteur d'Évènement de Symfony2 implémente le pattern
-`Observer`_ d'une manière simple et efficace pour rendre toutes ces
+`Mediator`_ d'une manière simple et efficace pour rendre toutes ces
 choses possibles et pour réaliser des projets vraiment extensibles.
 
 Prenez un exemple simple du `composant HttpKernel de Symfony2`_. Une fois
@@ -615,7 +615,7 @@ d'exécution du « listener »::
         }
     }
 
-.. _Observer: http://fr.wikipedia.org/wiki/Observateur_(patron_de_conception)
+.. _Mediator: https://fr.wikipedia.org/wiki/M%C3%A9diateur_(patron_de_conception)
 .. _`composant HttpKernel de Symfony2`: https://github.com/symfony/HttpKernel
 .. _Closures: http://www.php.net/manual/fr/functions.anonymous.php
 .. _callable PHP: http://www.php.net/manual/fr/language.pseudo-types.php#language.types.callback


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | yes
| New docs?     | no
| Applies to    | all
| Fixed tickets | none

See http://symfony.com/doc/current/components/event_dispatcher/introduction.html
